### PR TITLE
Support for pools and single host/port when using rethinkdbdash driver

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -39,9 +39,9 @@ function validateOptions (options) {
       .description('Directory where migration files will be saved'),
     relativeTo: Joi.string().default(process.cwd())
       .description('Root path from which migration directory will be searched'),
-    host: Joi.any().when('driver', { is: 'rethinkdb', then: Joi.string().default('localhost'), otherwise: Joi.any().forbidden() })
+    host: Joi.string().default('localhost')
       .description('The host to connect to, if using rethinkdb official driver'),
-    port: Joi.any().when('driver', { is: 'rethinkdb', then: Joi.number().default(28015), otherwise: Joi.any().forbidden() })
+    port: Joi.number().default(28015)
       .description('The port to connect on, if using rethinkdb official driver'),
     db: Joi.string().required().description('Database name'),
     user: Joi.string().description('Rethinkdb user'),
@@ -101,21 +101,23 @@ function wait (options) {
 function connectToRethink (options) {
   const r = selectDriver(options)
 
-  if (options.driver === 'rethinkdbdash' && options.pool) {
+  if (options.driver === 'rethinkdbdash' && options.servers && options.pool) {
     return Promise.resolve(Object.assign({}, options, { r }))
   }
 
-  return r.connect(Mask(options, 'host,port,user,username,password,authKey'))
-    .then(conn => {
-      return Object.assign({}, options, { r, conn })
-    })
+  if (options.host && options.port) {
+    return r.connect(Mask(options, 'db,host,port,user,username,password,authKey'))
+      .then(conn => {
+        return Object.assign({}, options, { r, conn })
+      })
+  }
 }
 
 function selectDriver (options) {
   if (options.driver === 'rethinkdb') {
     return require('rethinkdb')
   }
-  return require('rethinkdbdash')(Mask(options, 'db,user,username,password,authKey,discovery,pool,cursor,servers'))
+  return require('rethinkdbdash')(Mask(options, 'db,user,host,port,username,password,authKey,discovery,pool,cursor,servers'))
 }
 
 function createDbIfInexistent (options) {


### PR DESCRIPTION

Addresses #10 specifically with regards to supporting the use of rethinkdbdash driver with no pools and just a single host/port connection (see comment https://github.com/vinicius0026/rethinkdb-migrate/issues/10#issuecomment-284181403)

All tests pass.