### PR TITLE
Adding support for ssl connections to rethinkdb in migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ module.exports = {
   servers: [
     { host: "localhost", port: 28015 },
     { host: "localhost", port: 28016 }
-  ]
+  ],
+  ssl: false
 }
 ```
 

--- a/bin/rethinkdb-migrate
+++ b/bin/rethinkdb-migrate
@@ -111,7 +111,7 @@ function logger (emitter) {
  * an option present in the config file and also a environment variable, and so on
  */
 function buildOptions (argv) {
-  const optionsMask = 'name,migrationsDirectory,relativeTo,migrationsTable,host,port,db,user,username,password,authKey,driver,discovery,pool,cursor,servers'
+  const optionsMask = 'name,migrationsDirectory,relativeTo,migrationsTable,host,port,db,user,username,password,authKey,driver,discovery,pool,cursor,servers,ssl'
   const envVars = Mask(process.env, optionsMask)
   const file = Mask(readOptionsFile(argv), optionsMask)
   const args = Mask(argv, optionsMask)

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -64,10 +64,7 @@ function validateOptions (options) {
           .description('The port to connect on')
       }))
     }),
-    ssl: [Joi.boolean(), Joi.object().keys({
-      rejectUnauthorized: Joi.boolean().description('Whether rethinkdb driver should reject self-signed certificates'),
-      ca: Joi.string().description('Path to the certificate file: .crt')
-    }).description('Rethinkdb SSL/TLS support')]
+    ssl: Joi.alternatives().try(Joi.object(), Joi.boolean()).default(false).description('Rethinkdb SSL/TLS support')
   }).without('user', 'username').without('password', 'authKey').required()
 
   return new Promise((resolve, reject) => {

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -64,10 +64,10 @@ function validateOptions (options) {
           .description('The port to connect on')
       }))
     }),
-    ssl: Joi.object().keys({
+    ssl: [Joi.boolean(), Joi.object().keys({
       rejectUnauthorized: Joi.boolean().description('Whether rethinkdb driver should reject self-signed certificates'),
       ca: Joi.string().description('Path to the certificate file: .crt')
-    }).description('Rethinkdb SSL/TLS support')
+    }).description('Rethinkdb SSL/TLS support')]
   }).without('user', 'username').without('password', 'authKey').required()
 
   return new Promise((resolve, reject) => {

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -63,7 +63,11 @@ function validateOptions (options) {
         port: Joi.number().default(28015)
           .description('The port to connect on')
       }))
-    })
+    }),
+    ssl: Joi.object().keys({
+      rejectUnauthorized: Joi.boolean().description('Whether rethinkdb driver should reject self-signed certificates'),
+      ca: Joi.string().description('Path to the certificate file: .crt')
+    }).description('Rethinkdb SSL/TLS support')
   }).without('user', 'username').without('password', 'authKey').required()
 
   return new Promise((resolve, reject) => {
@@ -117,7 +121,7 @@ function selectDriver (options) {
   if (options.driver === 'rethinkdb') {
     return require('rethinkdb')
   }
-  return require('rethinkdbdash')(Mask(options, 'db,user,host,port,username,password,authKey,discovery,pool,cursor,servers'))
+  return require('rethinkdbdash')(Mask(options, 'db,user,host,port,username,password,authKey,discovery,pool,cursor,servers,ssl'))
 }
 
 function createDbIfInexistent (options) {


### PR DESCRIPTION
Currently rethinkdb-migrate doesn't support any SSL connections while running migrations.
This PR introduces support for it as we're using in our own setup too.