### PR TITLE
add support for running all migration files regardless of timestamp

### DIFF
--- a/bin/rethinkdb-migrate
+++ b/bin/rethinkdb-migrate
@@ -73,6 +73,9 @@ require('yargs')
   .alias('f', 'file')
   .nargs('f', 1)
   .describe('f', 'Uses the provided file as the options to be used when migration is run')
+  .alias('i', 'ignore-timestamp')
+  .nargs('i', 0)
+  .describe('i', 'Ignore timestamp when applying migrations')
   .help('h')
   .alias('h', 'help')
   .demandCommand(1)
@@ -111,7 +114,7 @@ function logger (emitter) {
  * an option present in the config file and also a environment variable, and so on
  */
 function buildOptions (argv) {
-  const optionsMask = 'name,migrationsDirectory,relativeTo,migrationsTable,host,port,db,user,username,password,authKey,driver,discovery,pool,cursor,servers,ssl'
+  const optionsMask = 'name,migrationsDirectory,relativeTo,migrationsTable,host,port,db,user,username,password,authKey,driver,discovery,pool,cursor,servers,ssl,i'
   const envVars = Mask(process.env, optionsMask)
   const file = Mask(readOptionsFile(argv), optionsMask)
   const args = Mask(argv, optionsMask)

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -35,6 +35,8 @@ function validateOptions (options) {
       .description('Rethinkdb javascript driver'),
     migrationsTable: Joi.string().default('_migrations')
       .description('Table where meta information about migrations will be saved'),
+    i: Joi.boolean().default(0)
+      .description('Ignore timestamp when applying migrations'),
     migrationsDirectory: Joi.string().default('migrations')
       .description('Directory where migration files will be saved'),
     relativeTo: Joi.string().default(process.cwd())
@@ -233,7 +235,7 @@ function getUnExecutedMigrations (latestExecutedMigration, options) {
       filename
     }
   }))
-  .then(migrations => filterMigrationsOlderThan(migrations, latestExecutedMigration.timestamp))
+  .then(migrations => filterMigrationsOlderThan(migrations, latestExecutedMigration.timestamp, options))
   .then(sortMigrations)
   .then(migrations => loadMigrationsCode(migrations, options))
 }
@@ -249,8 +251,11 @@ function readMigrationFilenamesFromPath (path) {
   })
 }
 
-function filterMigrationsOlderThan (migrations, reference) {
-  return migrations.filter(migration => migration.timestamp.isAfter(Moment(reference)))
+function filterMigrationsOlderThan (migrations, reference, options) {
+  if (!options.i) {
+    return migrations.filter(migration => migration.timestamp.isAfter(Moment(reference)))
+  }
+  return migrations
 }
 
 function loadMigrationsCode (migrations, options) {


### PR DESCRIPTION
Addresses #20 
The addition of the extra `i` or `--ignore-timestamp` flag isn't breaking any functionality and enables running all migrations, regardless of timestamp.