### PR TITLE
fixing support for verbose option ignoreTimestamp

### DIFF
--- a/bin/rethinkdb-migrate
+++ b/bin/rethinkdb-migrate
@@ -114,10 +114,17 @@ function logger (emitter) {
  * an option present in the config file and also a environment variable, and so on
  */
 function buildOptions (argv) {
-  const optionsMask = 'name,migrationsDirectory,relativeTo,migrationsTable,host,port,db,user,username,password,authKey,driver,discovery,pool,cursor,servers,ssl,i'
+  const optionsMask = 'name,migrationsDirectory,relativeTo,migrationsTable,host,port,db,user,username,password,authKey,driver,discovery,pool,cursor,servers,ssl,i,ignoreTimestamp'
   const envVars = Mask(process.env, optionsMask)
   const file = Mask(readOptionsFile(argv), optionsMask)
   const args = Mask(argv, optionsMask)
+
+  // normalize the -i / --ignore-timestamp option to result to ignoreTimestamp option
+  // for arguments input schema validation
+  if (args.hasOwnProperty('i')) {
+    delete args.i
+    args.ignoreTimestamp = true
+  }
 
   return Object.assign({}, envVars, file, args)
 }

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -35,7 +35,7 @@ function validateOptions (options) {
       .description('Rethinkdb javascript driver'),
     migrationsTable: Joi.string().default('_migrations')
       .description('Table where meta information about migrations will be saved'),
-    i: Joi.boolean().default(0)
+    ignoreTimestamp: Joi.boolean().default(0)
       .description('Ignore timestamp when applying migrations'),
     migrationsDirectory: Joi.string().default('migrations')
       .description('Directory where migration files will be saved'),
@@ -252,7 +252,7 @@ function readMigrationFilenamesFromPath (path) {
 }
 
 function filterMigrationsOlderThan (migrations, reference, options) {
-  if (!options.i) {
+  if (!options.ignoreTimestamp) {
     return migrations.filter(migration => migration.timestamp.isAfter(Moment(reference)))
   }
   return migrations


### PR DESCRIPTION
In reference to PR #21 - I noticed due to the joi schema validation we're not really supporting the verbose `--ignore-timestamp` option but only the short syntax `-i`.

This commit fixes it by cleanly normalizing -i to --ignoreTimestamp.
Fixed and tested locally.