### PR TITLE
feat(down): downgrading migrations support for relative directory

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -172,8 +172,8 @@ function migrateUp (options) {
 function migrateDown (options) {
   return getExecutedMigrations(options)
     .then(migrations => runMigrations('down', migrations, options))
-    .then(emit('info', 'Clearing migrations table'))
-    .then(() => clearMigrationsTable(options))
+    .then(migrations => clearMigrationsTable(migrations, options))
+    .then(emit('info', 'Cleared migrations table'))
     .then(() => options)
 }
 
@@ -218,7 +218,7 @@ function getAllMigrationsExecuted (options) {
     })))
 }
 
-function getExecutedMigrations (options) {
+function getMigrationsFromPath (options) {
   const { migrationsDirectory, relativeTo } = options
   const path = Path.resolve(relativeTo, migrationsDirectory)
   const migrationRegExp = /^(\d{14})-(.*)\.js$/
@@ -234,29 +234,20 @@ function getExecutedMigrations (options) {
         filename
       }
     }))
+}
+
+function getExecutedMigrations (options) {
+  return getMigrationsFromPath(options)
     .then(sortMigrations)
     .then(migrations => loadMigrationsCode(migrations, options))
 }
 
 function getUnExecutedMigrations (latestExecutedMigration, options) {
-  const { migrationsDirectory, relativeTo } = options
-  const path = Path.resolve(relativeTo, migrationsDirectory)
-  const migrationRegExp = /^(\d{14})-(.*)\.js$/
-
-  return readMigrationFilenamesFromPath(path)
-  .then(files => files.filter(file => file.match(migrationRegExp)))
-  .then(migrationFiles => migrationFiles.map(filename => {
-    const [, timestamp, name] = filename.match(migrationRegExp)
-
-    return {
-      timestamp: Moment.utc(timestamp, 'YYYYMMDDHHmmss'),
-      name: name,
-      filename
-    }
-  }))
-  .then(migrations => filterMigrationsOlderThan(migrations, latestExecutedMigration.timestamp, options))
-  .then(sortMigrations)
-  .then(migrations => loadMigrationsCode(migrations, options))
+  return getMigrationsFromPath(options)
+    .then(migrations => filterMigrationsOlderThan(migrations,
+      latestExecutedMigration.timestamp, options))
+    .then(sortMigrations)
+    .then(migrations => loadMigrationsCode(migrations, options))
 }
 
 function readMigrationFilenamesFromPath (path) {
@@ -313,10 +304,15 @@ function saveExecutedMigrationsMetadata (migrations, options) {
     .reduce((chain, migration) => chain.then(() => r.table(migrationsTable).insert(migration).run(conn)), Promise.resolve())
 }
 
-function clearMigrationsTable (options) {
+function clearMigrationsTable (migrations, options) {
   const { r, conn, migrationsTable } = options
 
-  return r.table(migrationsTable).delete().run(conn)
+  const migrationsToDelete = []
+  migrations.forEach((item) => {
+    migrationsToDelete.push(r.table(migrationsTable).filter({'filename': item.filename}).delete().run(conn))
+  })
+
+  return Promise.all(migrationsToDelete)
 }
 
 function closeConnection (options) {

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -170,8 +170,7 @@ function migrateUp (options) {
 }
 
 function migrateDown (options) {
-  return getAllMigrationsExecuted(options)
-    .then(migrations => loadMigrationsCode(migrations, options))
+  return getExecutedMigrations(options)
     .then(migrations => runMigrations('down', migrations, options))
     .then(emit('info', 'Clearing migrations table'))
     .then(() => clearMigrationsTable(options))
@@ -217,6 +216,26 @@ function getAllMigrationsExecuted (options) {
     .then(migrations => migrations.map(migration => Object.assign({}, migration, {
       timestamp: Moment.utc(migration.timestamp)
     })))
+}
+
+function getExecutedMigrations (options) {
+  const { migrationsDirectory, relativeTo } = options
+  const path = Path.resolve(relativeTo, migrationsDirectory)
+  const migrationRegExp = /^(\d{14})-(.*)\.js$/
+
+  return readMigrationFilenamesFromPath(path)
+    .then(files => files.filter(file => file.match(migrationRegExp)))
+    .then(migrationFiles => migrationFiles.map(filename => {
+      const [, timestamp, name] = filename.match(migrationRegExp)
+
+      return {
+        timestamp: Moment.utc(timestamp, 'YYYYMMDDHHmmss'),
+        name: name,
+        filename
+      }
+    }))
+    .then(sortMigrations)
+    .then(migrations => loadMigrationsCode(migrations, options))
 }
 
 function getUnExecutedMigrations (latestExecutedMigration, options) {

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -307,12 +307,14 @@ function saveExecutedMigrationsMetadata (migrations, options) {
 function clearMigrationsTable (migrations, options) {
   const { r, conn, migrationsTable } = options
 
-  const migrationsToDelete = []
-  migrations.forEach((item) => {
-    migrationsToDelete.push(r.table(migrationsTable).filter({'filename': item.filename}).delete().run(conn))
-  })
-
-  return Promise.all(migrationsToDelete)
+  return Promise.all(
+    migrations.map(
+      item => r.table(migrationsTable)
+        .filter({filename: item.filename})
+        .delete()
+        .run(conn)
+    )
+  )
 }
 
 function closeConnection (options) {

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -238,7 +238,7 @@ function getMigrationsFromPath (options) {
 
 function getExecutedMigrations (options) {
   return getMigrationsFromPath(options)
-    .then(sortMigrations)
+    .then(migrations => sortMigrations(migrations, true))
     .then(migrations => loadMigrationsCode(migrations, options))
 }
 
@@ -274,12 +274,12 @@ function loadMigrationsCode (migrations, options) {
   return migrations.map(migration => Object.assign({}, migration, { code: require(Path.resolve(basePath, migration.filename)) }))
 }
 
-function sortMigrations (migrations) {
+function sortMigrations (migrations, orderDesc = false) {
   return migrations.sort((a, b) => {
     if (a.timestamp.isBefore(b.timestamp)) {
-      return -1
+      return orderDesc ? 1 : -1
     } else if (b.timestamp.isBefore(a.timestamp)) {
-      return 1
+      return orderDesc ? -1 : 1
     }
     return 0
   })


### PR DESCRIPTION
Currently, `rethinkdb-migrate down` will consult the `_migration` table in the database to try and remove migrations one by one, even if specified a specific directory. The problem with that, is it will try to teardown migrations which don't exist in the provided directory.

This PR introduces support so that when you pass in `--migrationsDirectory somedir/` it will only teardown the migrations in that directory.
