### PR TITLE
output created file path

### DIFF
--- a/bin/rethinkdb-migrate
+++ b/bin/rethinkdb-migrate
@@ -88,7 +88,7 @@ function runCreate (argv) {
   const options = Mask(buildOptions(argv), 'name,migrationsDirectory,relativeTo')
 
   Migrations.create(options)
-    .then(() => console.log('Finished successfully'))
+    .then((path) => console.log(`Created ${path}`))
     .catch(console.error.bind(null, 'Error while running migrations:'))
 }
 

--- a/bin/rethinkdb-migrate
+++ b/bin/rethinkdb-migrate
@@ -89,7 +89,7 @@ function runCreate (argv) {
 
   Migrations.create(options)
     .then((path) => console.log(`Created ${path}`))
-    .catch(console.error.bind(null, 'Error while running migrations:'))
+    .catch(console.error.bind(null, 'Error while creating migrations:'))
 }
 
 function runMigrations (op, argv) {


### PR DESCRIPTION
Output the full path of the created migration script in the CLI

Fix the error message when an error occured for the migration script's creation (Error while *creating* migrations)