### PR TITLE
Ability to provide driver directly without closing connection when migrations are finished

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -27,7 +27,7 @@ Migrate.emitter = internals.emitter
 
 module.exports = Migrate
 
-function validateOptions (options) {
+function validateOptions(options) {
   const schema = Joi.object().keys({
     op: Joi.string().valid('up', 'down').required()
       .description('Migration command'),
@@ -35,6 +35,8 @@ function validateOptions (options) {
       .description('Number of migrations to perform (migrations are counted as each migration file)'),
     driver: Joi.string().valid('rethinkdb', 'rethinkdbdash').default('rethinkdb')
       .description('Rethinkdb javascript driver'),
+    r: Joi.any().description('An r rethinkdb driver object provided directly'),
+    dontCloseConnectionAfterMigrations: Joi.boolean().description('Used in combination with specifying r typically. In this case this module will not close the connection when finished.'),
     migrationsTable: Joi.string().default('_migrations')
       .description('Table where meta information about migrations will be saved'),
     ignoreTimestamp: Joi.boolean().default(0)
@@ -83,6 +85,7 @@ function validateOptions (options) {
   })
 }
 
+let hasAlreadyWaitedForReadyForWritesOnR = [];
 function wait (options) {
   if (options.driver === 'rethinkdb') {
     return Promise.resolve(options)
@@ -93,13 +96,16 @@ function wait (options) {
   return r.dbList().run(conn)
     .then(toArray)
     .then(list => {
-      if (list.indexOf(db) !== -1) {
+      if (list.indexOf(db) !== -1 && options.r && hasAlreadyWaitedForReadyForWritesOnR.indexOf(r) === -1) {
         return r
           .db(options.db).wait([
             { waitFor: 'ready_for_writes', timeout: 20 }
           ])
           .run(conn)
-          .then(() => options)
+          .then(() => {
+            hasAlreadyWaitedForReadyForWritesOnR.push(r);
+            return options
+          })
       }
       return Promise.resolve(options)
     })
@@ -107,6 +113,10 @@ function wait (options) {
 
 function connectToRethink (options) {
   const r = selectDriver(options)
+
+  if (options.r) {
+    return Promise.resolve(Object.assign({}, options));
+  }
 
   if (options.driver === 'rethinkdbdash' && options.servers && options.pool) {
     return Promise.resolve(Object.assign({}, options, { r }))
@@ -121,9 +131,14 @@ function connectToRethink (options) {
 }
 
 function selectDriver (options) {
+  if (options.r) {
+    return options.r;
+  }
+  
   if (options.driver === 'rethinkdb') {
     return require('rethinkdb')
   }
+
   return require('rethinkdbdash')(Mask(options, 'db,user,host,port,username,password,authKey,silent,discovery,pool,cursor,servers,ssl'))
 }
 
@@ -343,6 +358,10 @@ function clearMigrationsTable (migrations, options) {
 
 function closeConnection (options) {
   const { r, conn } = options
+
+  if (options.dontCloseConnectionAfterMigrations) {
+    return;
+  }
 
   if (options.driver === 'rethinkdbdash' && options.pool) {
     return r.getPoolMaster().drain()


### PR DESCRIPTION
This PR provides the ability to provide a r driver directly instead of initializing a new one specifically for the migration process. It also adds the ability to not close the connection at the end of the process so that the specified driver can continue to be used. 
Finally, if you pass in the same r driver multiple times, it will only wait for ready_for_writes once.

We have found this to be useful in our application where we apply migrations on startup across different areas of the app (eg call migrate multiple times) which was slowing down the app unnecessarily.