### PR TITLE
Log filename when executing migration

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -315,7 +315,7 @@ function runMigrations (direction, migrations, options) {
   const { r, conn } = options
   return migrations.reduce(
     (chain, migration) => chain.then(() => migration.code[direction](r, conn)
-      .then(emit('info', `Executed migration ${migration.name} ${options.op}`))),
+      .then(emit('info', `Executed migration ${migration.name} ${options.op} (file: ${migration.filename})`, options))),
     Promise.resolve()
   ).then(() => migrations)
 }


### PR DESCRIPTION
Adding the full filename being executed during the migration. 
Perhaps this is specific to our use case but we usually name our migration files based on release number and business area of the application that it applies to. Something like 20192205100500-service1-1.2.0.
We then use a different timestamp with the same migration name if we need another migration in that same release.
The timestamp therefore allows us to identify the release script we are executing precisely which is why logging the filename is useful we find.