### PR TITLE
Ability to provide additional event emitter to emit on

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -361,7 +361,7 @@ function emit (name, data, options) {
   return function (arg) {
     internals.emitter.emit(name, data)
     if (options && options.emitter) {
-      options.emitter.emit(name, data);
+      options.emitter.emit(name, data)
     }
     return arg
   }

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -10,14 +10,14 @@ const Path = require('path')
 const internals = {}
 
 const Migrate = function (opt) {
-  emit('info', 'Validating options')()
+  emit('info', 'Validating options', opt)()
   return validateOptions(opt)
-    .then(emit('info', 'Connecting to RethinkDB'))
+    .then(emit('info', 'Connecting to RethinkDB', opt))
     .then(connectToRethink)
     .then(createDbIfInexistent)
-    .then(emit('info', 'Executing Migrations'))
+    .then(emit('info', 'Executing Migrations', opt))
     .then(executeMigration)
-    .then(emit('info', 'Closing connection'))
+    .then(emit('info', 'Closing connection', opt))
     .then(closeConnection)
 }
 
@@ -69,7 +69,8 @@ function validateOptions (options) {
           .description('The port to connect on')
       }))
     }),
-    ssl: Joi.alternatives().try(Joi.object(), Joi.boolean()).default(false).description('Rethinkdb SSL/TLS support')
+    ssl: Joi.alternatives().try(Joi.object(), Joi.boolean()).default(false).description('Rethinkdb SSL/TLS support'),
+    emitter: Joi.any().description('An alternate event emitter on which to emit event')
   }).without('user', 'username').without('password', 'authKey').required()
 
   return new Promise((resolve, reject) => {
@@ -134,7 +135,7 @@ function createDbIfInexistent (options) {
     .then(toArray)
     .then(list => {
       if (list.indexOf(db) < 0) {
-        emit('info', 'Creating db', db)()
+        emit('info', 'Creating db', db, options)()
         return r.dbCreate(db).run(conn)
       }
     })
@@ -174,13 +175,13 @@ function migrateUp (options) {
       return migrationSteps
     })
     .then(migrationSteps => runMigrations('up', migrationSteps, options))
-    .then(emit('info', 'Saving metadata'))
+    .then(emit('info', 'Saving metadata', options))
     .then(executedMigrations => saveExecutedMigrationsMetadata(executedMigrations, options))
     .then(() => {
       const migrationMessage = steps
         ? `Executed ${steps} migration${steps > 1 ? 's' : ''}.`
         : `No migrations executed.`
-      emit('info', migrationMessage)()
+      emit('info', migrationMessage, options)()
     })
     .then(() => options)
 }
@@ -200,7 +201,7 @@ function migrateDown (options) {
       const migrationMessage = steps
         ? `Cleared ${steps} migration${steps > 1 ? 's' : ''} from table.`
         : 'Migrations table already clear.'
-      emit('info', migrationMessage)()
+      emit('info', migrationMessage, options)()
     })
     .then(() => options)
 }
@@ -315,7 +316,7 @@ function runMigrations (direction, migrations, options) {
   const { r, conn } = options
   return migrations.reduce(
     (chain, migration) => chain.then(() => migration.code[direction](r, conn)
-      .then(emit('info', `Executed migration ${migration.name} ${options.op}`))),
+      .then(emit('info', `Executed migration ${migration.name} ${options.op}`, options))),
     Promise.resolve()
   ).then(() => migrations)
 }
@@ -356,9 +357,12 @@ function closeConnection (options) {
   return conn.close()
 }
 
-function emit (name, data) {
+function emit (name, data, options) {
   return function (arg) {
     internals.emitter.emit(name, data)
+    if (options && options.emitter) {
+      options.emitter.emit(name, data);
+    }
     return arg
   }
 }


### PR DESCRIPTION
We call migrate on the startup of our application for each service that composes the application.
Whilst we can definitely use the migrate.emitter to log what is happening in our application, the fact that it is a shared instance on the migrate object makes it hard to log on the appropriate log category.
Here is a code example of the issue we face : 
```
//service 1
log = getLogger('service1')
migrate.emitter.on('info', (data)=> log.debug(data))
migrate(...)

//service 2
log = getLogger('service2')
migrate.emitter.on('info', (data)=> log.debug(data))
//this is now registering a second listener to the same emitter which will end up logging stuff from service 1 as well
migrate(...)
```

I can think of other was to solve this, eg making migrate a class that you instanciate intead of shared instance so that each instance would have its own emitter.
Or you could also have a 'label' option passed in to migrate which could be used to emit more specifically : 
```
//instead of 
internals.emitter.emit(name, data)
//do
internals.emitter.emit(`${name}-${options.label}`, data)
```